### PR TITLE
Bump Authorization Project

### DIFF
--- a/Authorization/Authorization.csproj
+++ b/Authorization/Authorization.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="GraphQL.AspNet" Version="1.2.3" />
-    <PackageReference Include="Microsoft.AspNet.Identity.Core" Version="2.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.39" />
   </ItemGroup>
 
 </Project>

--- a/Authorization/Users/AppRole.cs
+++ b/Authorization/Users/AppRole.cs
@@ -1,9 +1,6 @@
 ﻿namespace GraphQL.AspNet.Examples.Authorization.Users
 {
-    using System;
-    using Microsoft.AspNet.Identity;
-
-    public class AppRole : IRole<string>
+    public class AppRole
     {
         public AppRole(string id, string name)
         {
@@ -13,7 +10,6 @@
         }
 
         public string Id { get; }
-
         public string Name { get; set; }
         public string NormalizedName { get; set; }
     }

--- a/Authorization/Users/AppUser.cs
+++ b/Authorization/Users/AppUser.cs
@@ -1,8 +1,6 @@
 ﻿namespace GraphQL.AspNet.Examples.Authorization.Users
 {
-    using Microsoft.AspNet.Identity;
-
-    public class AppUser : IUser<string>
+    public class AppUser
     {
         public AppUser(string id, string username)
         {

--- a/Custom-Directives/Startup.cs
+++ b/Custom-Directives/Startup.cs
@@ -1,7 +1,6 @@
 namespace GraphQL.AspNet.Examples.CustomDirectives
 {
     using GraphQL.AspNet.Configuration;
-    using GraphQL.AspNet.Configuration;
     using GraphQL.AspNet.Examples.CustomDirectives.Directives;
     using GraphQL.AspNet.Examples.CustomDirectives.Model;
     using Microsoft.AspNetCore.Builder;


### PR DESCRIPTION
* Fixed an issue with a deprecated package on authorization demo project. No functionality changes.

Old: `Microsoft.AspNet.Identity.Core     v2.2.3`
New: `Microsoft.AspNetCore.Identity     v2.1.39`